### PR TITLE
Add package tree to list of install targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN dnf install -y \
         tar \
         texinfo \
         tmux \
+        tree \
         unzip \
         wget \
         which \
@@ -65,3 +66,4 @@ RUN groupadd -g 4040 yocto && \
 USER yocto
 WORKDIR ${YOCTO_DIR}
 CMD ["/bin/bash"]
+


### PR DESCRIPTION
Add tree tool to the list of packages that get installed in base image
as it is of great help to get a brief overview regarding the plethora
of recipes and layers in the Yocto build container.