### PR TITLE
Update Hadolint Action to 1.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@main
       - name: Build
         run: podman build --file fedora-${{ matrix.fc_version }}/Dockerfile --tag ${FULL_IMAGE_TAG} .
-      - uses: hadolint/hadolint-action@v1.5.0
+      - uses: hadolint/hadolint-action@v1.6.0
         with:
           dockerfile: fedora-${{ matrix.fc_version}}/Dockerfile
       - name: Deploy


### PR DESCRIPTION
Updates Hadolint Action to 1.6.0 which ships the latest linter version.