### PR TITLE
Add OpenContainers image spec annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@main
       - name: Build
-        run: podman build --file fedora-${{ matrix.fc_version }}/Dockerfile --tag ${FULL_IMAGE_TAG} .
+        run: |
+          podman build --file fedora-${{ matrix.fc_version }}/Dockerfile --tag ${FULL_IMAGE_TAG} \
+            --label org.opencontainers.image.created="$(date --rfc-3339=seconds --utc)" \
+            --label org.opencontainers.image.revision="${GITHUB_SHA}"
       - uses: hadolint/hadolint-action@v1.6.0
         with:
           dockerfile: fedora-${{ matrix.fc_version}}/Dockerfile

--- a/fedora-32/Dockerfile
+++ b/fedora-32/Dockerfile
@@ -1,5 +1,13 @@
 FROM fedora:32 
 
+LABEL \
+    org.opencontainers.image.title="yocto" \
+    org.opencontainers.image.description="Fedora based image for Yocto builds" \
+    org.opencontainers.image.source="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.documentation="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.vendor="jhnc-oss" \
+    org.opencontainers.image.licenses="MIT"
+
 RUN dnf install -y \
         bzip2 \
         ccache \

--- a/fedora-33/Dockerfile
+++ b/fedora-33/Dockerfile
@@ -1,5 +1,13 @@
 FROM fedora:33
 
+LABEL \
+    org.opencontainers.image.title="yocto" \
+    org.opencontainers.image.description="Fedora based image for Yocto builds" \
+    org.opencontainers.image.source="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.documentation="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.vendor="jhnc-oss" \
+    org.opencontainers.image.licenses="MIT"
+
 RUN dnf install -y \
         bzip2 \
         ccache \

--- a/fedora-34/Dockerfile
+++ b/fedora-34/Dockerfile
@@ -1,5 +1,13 @@
 FROM fedora:34 
 
+LABEL \
+    org.opencontainers.image.title="yocto" \
+    org.opencontainers.image.description="Fedora based image for Yocto builds" \
+    org.opencontainers.image.source="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.documentation="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.vendor="jhnc-oss" \
+    org.opencontainers.image.licenses="MIT"
+
 RUN dnf install -y \
         bzip2 \
         ccache \


### PR DESCRIPTION
Adds basic [image spec annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md). Build time and revision are set by the CI build.