### PR TITLE
Add Fedora 35 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 32, 33, 34 ]
+        fc_version: [ 32, 33, 34, 35 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_TAG: "yocto:${{ matrix.fc_version }}"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 
 | Tag | Base | Status |
 |:---:|:----:|:------:|
+| `35` | Fedora 35 | |
 | `34` / `latest` | Fedora 34 | |
 | `33` | Fedora 33 | |
 | `32` | Fedora 32 | EOL |

--- a/fedora-32/Dockerfile
+++ b/fedora-32/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32 
+FROM fedora:32
 
 LABEL \
     org.opencontainers.image.title="yocto" \

--- a/fedora-35/Dockerfile
+++ b/fedora-35/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:35
 
 LABEL \
     org.opencontainers.image.title="yocto" \


### PR DESCRIPTION
Adds Fedora 35 image (#17). Since it's very new, I'd suggest to keep `latest` on 34 for now.