### PR TITLE
Fix package Fedora 35 conflict

### DIFF
--- a/fedora-32/Dockerfile
+++ b/fedora-32/Dockerfile
@@ -8,7 +8,8 @@ LABEL \
     org.opencontainers.image.vendor="jhnc-oss" \
     org.opencontainers.image.licenses="MIT"
 
-RUN dnf install -y \
+RUN dnf remove -y remove vim-minimal && \
+    dnf install -y \
         bzip2 \
         ccache \
         chrpath \

--- a/fedora-33/Dockerfile
+++ b/fedora-33/Dockerfile
@@ -8,7 +8,8 @@ LABEL \
     org.opencontainers.image.vendor="jhnc-oss" \
     org.opencontainers.image.licenses="MIT"
 
-RUN dnf install -y \
+RUN dnf remove -y remove vim-minimal && \
+    dnf install -y \
         bzip2 \
         ccache \
         chrpath \

--- a/fedora-34/Dockerfile
+++ b/fedora-34/Dockerfile
@@ -8,7 +8,8 @@ LABEL \
     org.opencontainers.image.vendor="jhnc-oss" \
     org.opencontainers.image.licenses="MIT"
 
-RUN dnf install -y \
+RUN dnf remove -y remove vim-minimal && \
+    dnf install -y \
         bzip2 \
         ccache \
         chrpath \

--- a/fedora-35/Dockerfile
+++ b/fedora-35/Dockerfile
@@ -8,7 +8,8 @@ LABEL \
     org.opencontainers.image.vendor="jhnc-oss" \
     org.opencontainers.image.licenses="MIT"
 
-RUN dnf install -y \
+RUN dnf remove -y remove vim-minimal && \
+    dnf install -y \
         bzip2 \
         ccache \
         chrpath \


### PR DESCRIPTION
Fixes the package vim package conflict (#26). Since this a known issue for various fedora versions, it's backported to all versions - even though they are not affected at the moment.

closes #26 