### PR TITLE
Remove localedef

### DIFF
--- a/fedora-32/Dockerfile
+++ b/fedora-32/Dockerfile
@@ -62,7 +62,6 @@ RUN dnf remove -y vim-minimal && \
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
-RUN localedef --force -i en_US -f UTF-8 en_US.UTF-8
 
 ENV YOCTO_DIR="/opt/yocto"
 RUN groupadd -g 4040 yocto && \

--- a/fedora-33/Dockerfile
+++ b/fedora-33/Dockerfile
@@ -62,7 +62,6 @@ RUN dnf remove -y vim-minimal && \
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
-RUN localedef --force -i en_US -f UTF-8 en_US.UTF-8
 
 ENV YOCTO_DIR="/opt/yocto"
 RUN groupadd -g 4040 yocto && \

--- a/fedora-34/Dockerfile
+++ b/fedora-34/Dockerfile
@@ -66,7 +66,6 @@ RUN dnf remove -y vim-minimal && \
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
-RUN localedef --force -i en_US -f UTF-8 en_US.UTF-8
 
 ENV YOCTO_DIR="/opt/yocto"
 RUN groupadd -g 4040 yocto && \

--- a/fedora-35/Dockerfile
+++ b/fedora-35/Dockerfile
@@ -66,7 +66,6 @@ RUN dnf remove -y vim-minimal && \
 
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
-RUN localedef --force -i en_US -f UTF-8 en_US.UTF-8
 
 ENV YOCTO_DIR="/opt/yocto"
 RUN groupadd -g 4040 yocto && \


### PR DESCRIPTION
`localedef` silently fails and causes errors when starting the container.

closes #29 