### PR TITLE
Always exclude PRs from registry push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           dockerfile: fedora-${{ matrix.fc_version}}/Dockerfile
       - name: Deploy
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: |
           podman login ghcr.io -u ${{ github.actor }} --password-stdin <<< ${{ secrets.GITHUB_TOKEN }}
           podman push ${FULL_IMAGE_NAME}:${{ matrix.fc_version }}


### PR DESCRIPTION
Even though testing for `main` should be enough, a general exclude of PR makes sense.