### PR TITLE
Remove Fedora 32 and 33 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 32, 33, 34, 35 ]
+        fc_version: [ 34, 35 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"


### PR DESCRIPTION
Removes builds of EOL Fedora versions. Dockerfiles and images in the registry are still available, but builds don't make sense since there are no updates any more.