### PR TITLE
Fedora 36 (Beta)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 34, 35 ]
+        fc_version: [ 34, 35, 36 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 
 | Tag | Base | Status |
 |:---:|:----:|:------:|
+| `36` | Fedora 36 | Beta |
 | `35` | Fedora 35 | |
 | `34` / `latest` | Fedora 34 | |
 | `33` | Fedora 33 | EOL |

--- a/fedora-36/Dockerfile
+++ b/fedora-36/Dockerfile
@@ -1,0 +1,78 @@
+FROM docker.io/fedora:36
+
+LABEL \
+    org.opencontainers.image.title="yocto" \
+    org.opencontainers.image.description="Fedora based image for Yocto builds" \
+    org.opencontainers.image.source="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.documentation="https://github.com/jhnc-oss/yocto-image" \
+    org.opencontainers.image.vendor="jhnc-oss" \
+    org.opencontainers.image.licenses="MIT"
+
+RUN dnf remove -y vim-minimal && \
+    dnf install -y \
+        bzip2 \
+        ccache \
+        chrpath \
+        cpio \
+        cpp \
+        diffstat \
+        diffutils \
+        file \
+        findutils \
+        gawk \
+        gcc \
+        gcc-c++ \
+        git \
+        glibc-locale-source \
+        glibc-devel \
+        glibc-langpack-en \
+        glibc-locale-source \
+        gzip \
+        hostname \
+        make \
+        mesa-libGL-devel \
+        patch \
+        perl \
+        perl-bignum \
+        perl-Data-Dumper \
+        perl-File-Compare \
+        perl-File-Copy \
+        perl-FindBin \
+        perl-locale \
+        perl-Text-ParseWords \
+        perl-Thread-Queue \
+        python \
+        python3 \
+        python3-GitPython \
+        python3-jinja2 \
+        python3-pexpect \
+        python3-pip \
+        rpcgen \
+        SDL-devel \
+        socat \
+        tar \
+        texinfo \
+        tmux \
+        tree \
+        unzip \
+        vim \
+        wget \
+        which \
+        xterm \
+        xz \
+        langpacks-en && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+ENV YOCTO_DIR="/opt/yocto"
+RUN groupadd -g 4040 yocto && \
+    adduser yocto -d ${YOCTO_DIR} -g yocto -u 1006 && \
+    echo "%yocto ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/yocto && \
+    chmod 0440 /etc/sudoers.d/yocto
+
+USER yocto
+WORKDIR ${YOCTO_DIR}
+CMD ["/bin/bash"]

--- a/fedora-36/Dockerfile
+++ b/fedora-36/Dockerfile
@@ -75,4 +75,11 @@ RUN groupadd -g 4040 yocto && \
 
 USER yocto
 WORKDIR ${YOCTO_DIR}
+
+ENV PATH="${YOCTO_DIR}/.local/bin:${PATH}"
+RUN pip install --no-cache-dir --user -U gitrepo==2.15.4.post1 && \
+    git config --global user.name yocto && \
+    git config --global user.email yocto@localhost && \
+    git config --global color.ui always
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
Adds the Fedora 36 image (#40).

It's marked as beta for now; the final end user release date is planed for ~~26.04.2022~~ ~~03.05.2022~~ 10.05.2022.