### PR TITLE
Install 'repo'

### DIFF
--- a/fedora-34/Dockerfile
+++ b/fedora-34/Dockerfile
@@ -75,5 +75,11 @@ RUN groupadd -g 4040 yocto && \
 
 USER yocto
 WORKDIR ${YOCTO_DIR}
-CMD ["/bin/bash"]
 
+ENV PATH="${YOCTO_DIR}/.local/bin:${PATH}"
+RUN pip install --no-cache-dir --user -U gitrepo==2.15.4.post1 && \
+    git config --global user.name yocto && \
+    git config --global user.email yocto@localhost && \
+    git config --global color.ui always
+
+CMD ["/bin/bash"]

--- a/fedora-35/Dockerfile
+++ b/fedora-35/Dockerfile
@@ -75,5 +75,11 @@ RUN groupadd -g 4040 yocto && \
 
 USER yocto
 WORKDIR ${YOCTO_DIR}
-CMD ["/bin/bash"]
 
+ENV PATH="${YOCTO_DIR}/.local/bin:${PATH}"
+RUN pip install --no-cache-dir --user -U gitrepo==2.15.4.post1 && \
+    git config --global user.name yocto && \
+    git config --global user.email yocto@localhost && \
+    git config --global color.ui always
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Installs `repo`; git configs are necessary to avoid interactive settings (#45).

:information_source: No backported to EOL Dockerfiles (< 34)