### PR TITLE
EOL 'latest'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
         run: |
           podman login ghcr.io -u ${{ github.actor }} --password-stdin <<< ${{ secrets.GITHUB_TOKEN }}
           podman push ${FULL_IMAGE_NAME}:${{ matrix.fc_version }}
-          if [[ ${{ matrix.fc_version}} -eq 34 ]]; then
-            podman push ${FULL_IMAGE_NAME}:${{ matrix.fc_version }} ${FULL_IMAGE_NAME}:latest
-          fi
 
   hadolint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 |:---:|:----:|:------:|
 | `36` | Fedora 36 | |
 | `35` | Fedora 35 | |
-| `34` / `latest` | Fedora 34 | |
+| `34` | Fedora 34 | |
 | `33` | Fedora 33 | EOL |
 | `32` | Fedora 32 | EOL |
+| `latest` | Fedora 34 | EOL |
 
 ## Local build
 


### PR DESCRIPTION
Marks `latest` as EOL and removes it's build (#48). The tag should be removed after some grace period to avoid usages without an explicit version.
