### PR TITLE
Remove no longer available 'latest' from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 | `34` | Fedora 34 | |
 | `33` | Fedora 33 | EOL |
 | `32` | Fedora 32 | EOL |
-| `latest` | Fedora 34 | EOL |
 
 ## Local build
 


### PR DESCRIPTION
`latest` is no longer available (see #48).