### PR TITLE
Update hadolint-action to 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
     name: "Hadolint"
     steps:
       - uses: actions/checkout@main
-      - uses: hadolint/hadolint-action@v2.1.0
+      - uses: hadolint/hadolint-action@v3.0.0
         with:
           recursive: true


### PR DESCRIPTION
Updates hadolint-action to it's latest release, featuring hadolint 2.12.