### PR TITLE
Remove 'Beta' from FC38 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 
 | Tag | Base | Status |
 |:---:|:----:|:------:|
-| `38` | Fedora 38 | Beta |
+| `38` | Fedora 38 | |
 | `37` | Fedora 37 | |
 | `36` | Fedora 36 | |
 | `35` | Fedora 35 | |


### PR DESCRIPTION
Stable Fedora 38 is available (#73).