### PR TITLE
Remove gettext from image

### DIFF
--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -24,7 +24,6 @@ RUN dnf remove -y vim-minimal && \
         gawk \
         gcc \
         gcc-c++ \
-        gettext \
         git \
         glibc-devel \
         glibc-devel.i686 \


### PR DESCRIPTION
gettext isn't needed after all as it can be used in yocto recipes through "inherit gettext"