### PR TITLE
Disable color.ui of gitconfig as it breaks devtool

### DIFF
--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -88,7 +88,7 @@ ENV PATH="${YOCTO_DIR}/.local/bin:${PATH}"
 RUN pip install --no-cache-dir --user -U gitrepo==2.31.1 && \
     git config --global user.name yocto && \
     git config --global user.email yocto@localhost && \
-    git config --global color.ui always && \
+    git config --global color.ui never && \
     git config --global init.defaultBranch "main"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
devtool fails during git checkout as branch contains ansi escape sequences (**?[32mdevtool?[m**) as depicted below:

```
INFO: Updating patch 0001-update.patch
Traceback (most recent call last):
  File "<path/to>/devtool", line 334, in <module>
    ret = main()
  File "<path/to>/devtool", line 321, in main
    ret = args.func(args, config, basepath, workspace)
  File "<path/to>/devtool/standard.py", line 1856, in update_recipe
    updated, _, _ = _update_recipe(args.recipename, workspace, rd, args.mode, args.append, args.wildcard_version, args.no_remove, args.initial_rev, dry_run_outdir=dry_run_outdir, no_overrides=args.no_overrides, force_patch_refresh=args.force_patch_refresh)
  File "<path/to>/standard.py", line 1828, in _update_recipe
    bb.process.run('git checkout %s' % startbranch, cwd=srctree)
  File "<path/to>/bb/process.py", line 185, in run
    raise ExecutionError(cmd, pipe.returncode, stdout, stderr)
bb.process.ExecutionError: Execution of 'git checkout devtool' failed with exit code 1:
error: pathspec '?[32mdevtool?[m' did not match any file(s) known to git
```