### PR TITLE
EOL Fedora 34 and 35 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 34, 35, 36, 37, 38 ]
+        fc_version: [ 36, 37, 38 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 | `38` | Fedora 38 | |
 | `37` | Fedora 37 | |
 | `36` | Fedora 36 | |
-| `35` | Fedora 35 | Deprecated |
-| `34` | Fedora 34 | Deprecated |
+| `35` | Fedora 35 | EOL |
+| `34` | Fedora 34 | EOL |
 | `33` | Fedora 33 | EOL |
 | `32` | Fedora 32 | EOL |
 


### PR DESCRIPTION
Updates documentation and removes the build of Fedora 34 and 35.