### PR TITLE
Add Fedora 39 image 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 36, 37, 38 ]
+        fc_version: [ 36, 37, 38, 39 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 
 | Tag | Base | Status |
 |:---:|:----:|:------:|
+| `39` | Fedora 39 | |
 | `38` | Fedora 38 | |
 | `37` | Fedora 37 | |
 | `36` | Fedora 36 | |


### PR DESCRIPTION
Builds a Fedora 39 based image.

closes #91 