### PR TITLE
Deprecate Fedora 36 based image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 | `39` | Fedora 39 | |
 | `38` | Fedora 38 | |
 | `37` | Fedora 37 | |
-| `36` | Fedora 36 | |
+| `36` | Fedora 36 | Deprecated |
 | `35` | Fedora 35 | EOL |
 | `34` | Fedora 34 | EOL |
 | `33` | Fedora 33 | EOL |


### PR DESCRIPTION
I'd suggest we deprecate the Fedora 36 image. This is a documentation only change for now, the build etc. remains unchanged. However, we should consider moving FC36 to EOL in the not too far away future.