### PR TITLE
Remove x86 support

### DIFF
--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -27,15 +27,12 @@ RUN dnf update -y && \
         gcc-c++ \
         git \
         glibc-devel \
-        glibc-devel.i686 \
         glibc-langpack-en \
         glibc-locale-source \
         gzip \
         hostname \
         langpacks-en \
-        libatomic.i686 \
-        libstdc++-static.i686 \
-        libstdc++-static.x86_64 \
+        libstdc++-static \
         lz4 \
         make \
         mesa-libGL-devel \


### PR DESCRIPTION
Removes x86 support related packages (closes #100).

This affects only current images, listed in the readme.