### PR TITLE
EOL Fedora 37 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 37, 38, 39 ]
+        fc_version: [ 38, 39 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 |:---:|:----:|:------:|
 | `39` | Fedora 39 | |
 | `38` | Fedora 38 | |
-| `37` | Fedora 37 | |
+| `37` | Fedora 37 | EOL |
 | `36` | Fedora 36 | EOL |
 | `35` | Fedora 35 | EOL |
 | `34` | Fedora 34 | EOL |


### PR DESCRIPTION
Fedora 37 is EOL and we do not use it much anyway.