### PR TITLE
Fedora 40 based image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 38, 39 ]
+        fc_version: [ 38, 39, 40 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 
 | Tag | Base | Status |
 |:---:|:----:|:------:|
+| `40` | Fedora 40 | Beta |
 | `39` | Fedora 39 | |
 | `38` | Fedora 38 | |
 | `37` | Fedora 37 | EOL |

--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -52,6 +52,7 @@ RUN dnf update -y && \
         python3-jinja2 \
         python3-pexpect \
         python3-pip \
+        python3-setuptools \
         ripgrep \
         rpcgen \
         SDL-devel \


### PR DESCRIPTION
Adds a Fedora 40 based image, marked as *Beta* for now (closes #97).

Installation of setuptools is necessary at least on FC40 to fix a 'No module named pkg_resources' error.