### PR TITLE
Provide krb5 and toml by default

### DIFF
--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -19,9 +19,9 @@ RUN dnf update -y && \
         cpp \
         diffstat \
         diffutils \
+        fd-find \
         file \
         findutils \
-        fd-find \
         gawk \
         gcc \
         gcc-c++ \
@@ -31,6 +31,7 @@ RUN dnf update -y && \
         glibc-locale-source \
         gzip \
         hostname \
+        krb5-devel \
         langpacks-en \
         libstdc++-static \
         lz4 \
@@ -48,11 +49,13 @@ RUN dnf update -y && \
         perl-Thread-Queue \
         python \
         python3 \
+        python3-devel \
         python3-GitPython \
         python3-jinja2 \
         python3-pexpect \
         python3-pip \
         python3-setuptools \
+        python3-toml \
         ripgrep \
         rpcgen \
         SDL-devel \


### PR DESCRIPTION
Add krb5, python3-devel,toml to list of default packages to provide built-in tools without depending on soon to be vanished upstream feeds for older releases such as FC38.