### PR TITLE
Add libacl

### DIFF
--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -33,6 +33,7 @@ RUN dnf update -y && \
         hostname \
         krb5-devel \
         langpacks-en \
+        libacl \
         libstdc++-static \
         lz4 \
         make \


### PR DESCRIPTION
The [required packages list](https://docs.yoctoproject.org/ref-manual/system-requirements.html#fedora-packages) of the manual (version 5.1 Styhead) contains libacl, which isn't present in our packages.

There are no issues so far, but since the manual explicitly mentions it, there may be a specific reason for its inclusion.