### PR TITLE
EOL Fedora 39 based image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 38, 39, 40, 41 ]
+        fc_version: [ 38, 40, 41 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 |:---:|:----:|:------:|
 | `41` | Fedora 41 | |
 | `40` | Fedora 40 | |
-| `39` | Fedora 39 | |
+| `39` | Fedora 39 | EOL |
 | `38` | Fedora 38 | |
 | `37` | Fedora 37 | EOL |
 | `36` | Fedora 36 | EOL |


### PR DESCRIPTION
Fedora 39 is [EOL since 2024-11-26](https://docs.fedoraproject.org/en-US/releases/eol/).