### PR TITLE
Add cargo, quilt to default installation

### DIFF
--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -13,6 +13,7 @@ LABEL \
 RUN dnf update -y && \
     dnf install -y \
         bzip2 \
+        cargo \
         ccache \
         chrpath \
         cpio \
@@ -57,6 +58,7 @@ RUN dnf update -y && \
         python3-pip \
         python3-setuptools \
         python3-toml \
+        quilt \
         ripgrep \
         rpcgen \
         SDL-devel \


### PR DESCRIPTION
Add cargo, quilt to default installation to avoid the need for an active package feed (especially when it comes to older images such as Fedora Core 38) a.k.a batteries included

Fixes (#112)