### PR TITLE
EOL Fedora 41 based image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        fc_version: [ 38, 40, 41, 42, 43 ]
+        fc_version: [ 38, 40, 42, 43 ]
     name: "Build yocto:${{ matrix.fc_version}}"
     env:
       FULL_IMAGE_NAME: "ghcr.io/${{ github.repository }}/yocto"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Images are available on [GHCR](https://github.com/jhnc-oss/yocto-image/pkgs/cont
 |:---:|:----:|:------:|
 | `43` | Fedora 43 | |
 | `42` | Fedora 42 | |
-| `41` | Fedora 41 | |
+| `41` | Fedora 41 | EOL |
 | `40` | Fedora 40 | |
 | `39` | Fedora 39 | EOL |
 | `38` | Fedora 38 | |


### PR DESCRIPTION
Fedora 41 is eol since 15 Dec 2025.