### PR TITLE
Drop the default Fedora version

### DIFF
--- a/yocto-fc/Dockerfile
+++ b/yocto-fc/Dockerfile
@@ -1,4 +1,4 @@
-ARG FC_VERSION=36
+ARG FC_VERSION
 
 FROM docker.io/fedora:${FC_VERSION}
 


### PR DESCRIPTION
The default value is already outdated and shouldn't be used anyway.